### PR TITLE
27 setupsh not installing extension correctly

### DIFF
--- a/test/setup.sh
+++ b/test/setup.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 set -e -x
-#Assume that test.gitconfig is in the same folder as this script
-gh repo create $(git config --file test.gitconfig setup.dest-repo) --add-readme --description "Description of testrepo" --public
 
-pushd $(git rev-parse --show-toplevel)/
-gh repo clone $(gh api user --jq '.login')/$(git config --file ./test/test.gitconfig setup.dest-repo)
-pushd $(git config --file ./test/test.gitconfig setup.dest-repo)
-ln -s ../gh-cpissues gh-cpissues
+#Assume that test.gitconfig is in the same folder as this script
+ROOT_DIR=$(git rev-parse --show-toplevel)
+USER=$(gh api user --jq '.login')
+
+path_to_gitconfig=$ROOT_DIR/test/test.gitconfig
+
+DEST_REPO=$(git config --file $path_to_gitconfig setup.dest-repo)
+README=$(git config --file $path_to_gitconfig setup.readme)
+
+gh repo create $DEST_REPO --add-readme --description "$README" --public
+
+pushd $ROOT_DIR/
+gh repo clone $USER/$DEST_REPO
 gh extension install .
-popd
 popd

--- a/test/teardown.sh
+++ b/test/teardown.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 set -e -x
-#Assume that test.gitconfig is in the same folder as this script
-gh repo delete $(gh api user --jq '.login')/$(git config --file test.gitconfig setup.dest-repo) --yes
-rm -rf $(git rev-parse --show-toplevel)/$(git config --file test.gitconfig setup.dest-repo)
+
+#Assume that test.gitconfig has the correct path
+ROOT_DIR=$(git rev-parse --show-toplevel)
+USER=$(gh api user --jq '.login')
+
+path_to_gitconfig=$ROOT_DIR/test/test.gitconfig
+DEST_REPO=$(git config --file $path_to_gitconfig setup.dest-repo)
+
+gh extension remove "cpissues"
+gh repo delete $USER/$DEST_REPO --yes
+rm -rf $ROOT_DIR/$DEST_REPO

--- a/test/test.gitconfig
+++ b/test/test.gitconfig
@@ -1,2 +1,3 @@
 [setup]
     dest-repo = _testrepo
+    readme = "Desc of testrepo"

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -e -x
-
-cd $(git rev-parse --show-toplevel)/$(git config --file test.gitconfig setup.dest-repo)
-gh cpissues thetechcollective/gh-cpissues --label testsample 


### PR DESCRIPTION
Removed symbolic link as gh extensions are downloaded for the current session.
Added functionality so that setup and teardown can be run from outside of /test